### PR TITLE
As a CMR Operator, I want all necessary evaluation metrics to be logged, so I have visibility into system performance.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.0-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.1-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -24,9 +24,9 @@
   :exclusions [gov.nasa.earthdata/cmr-http-kit]
   :dependencies [
     [gov.nasa.earthdata/cmr-authz "0.1.1"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+    [gov.nasa.earthdata/cmr-exchange-common "0.2.3"]
     [gov.nasa.earthdata/cmr-exchange-query "0.2.0"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
+    [gov.nasa.earthdata/cmr-http-kit "0.1.6"]
     [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-site-templates "0.1.0"]

--- a/src/cmr/sizing/app/handler.clj
+++ b/src/cmr/sizing/app/handler.clj
@@ -4,7 +4,9 @@
    [cmr.authz.token :as token]
    [cmr.http.kit.response :as response]
    [cmr.sizing.core :as sizing]
-   [taoensso.timbre :as log]))
+   [taoensso.timbre :as log])
+  (:import
+    (java.util UUID)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Size Estimate Handlers   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -15,7 +17,7 @@
   (fn [req]
     (log/debug "Estimating download size based on HTTP GET ...")
     (let [user-token (token/extract req)
-          request-id (str (java.util.UUID/randomUUID))
+          request-id (str (UUID/randomUUID))
           concept-id (get-in req [:path-params :concept-id])]
       (->> req
            :params

--- a/src/cmr/sizing/app/handler.clj
+++ b/src/cmr/sizing/app/handler.clj
@@ -15,10 +15,12 @@
   (fn [req]
     (log/debug "Estimating download size based on HTTP GET ...")
     (let [user-token (token/extract req)
+          request-id (str (java.util.UUID/randomUUID))
           concept-id (get-in req [:path-params :concept-id])]
       (->> req
            :params
-           (merge {:collection-id concept-id})
+           (merge {:collection-id concept-id
+                   :request-id request-id})
            (sizing/estimate-size component user-token)
            ;; We may need to override this in our own response ns if the base
            ;; error handler in cmr.http.kit isn't sufficient ...

--- a/src/cmr/sizing/app/handler.clj
+++ b/src/cmr/sizing/app/handler.clj
@@ -4,9 +4,7 @@
    [cmr.authz.token :as token]
    [cmr.http.kit.response :as response]
    [cmr.sizing.core :as sizing]
-   [taoensso.timbre :as log])
-  (:import
-    (java.util UUID)))
+   [taoensso.timbre :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Size Estimate Handlers   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -17,12 +15,10 @@
   (fn [req]
     (log/debug "Estimating download size based on HTTP GET ...")
     (let [user-token (token/extract req)
-          request-id (str (UUID/randomUUID))
           concept-id (get-in req [:path-params :concept-id])]
       (->> req
            :params
-           (merge {:collection-id concept-id
-                   :request-id request-id})
+           (merge {:collection-id concept-id})
            (sizing/estimate-size component user-token)
            ;; We may need to override this in our own response ns if the base
            ;; error handler in cmr.http.kit isn't sufficient ...

--- a/src/cmr/sizing/core.clj
+++ b/src/cmr/sizing/core.clj
@@ -48,17 +48,23 @@
            errs)
          (let [spatial-estimate (spatial/estimate-size
                                  format-estimate
-                                 results)]
+                                 results)
+               params (:params results)]
            (if-let [errs (errors/erred? spatial-estimate)]
              (do
                (log/error errs)
                errs)
-             (let [estimate spatial-estimate]
-               (log/debug "Generated estimate:" estimate)
+             (let [estimate spatial-estimate
+                   elapsed (util/timed start)]
+               (log/info (format "request-id: %s estimate: %s elapsed: %s"
+                                 (:request-id params)
+                                 estimate
+                                 elapsed))
                (results/create [{:bytes estimate
                                  :mb (/ estimate (Math/pow 2 20))
                                  :gb (/ estimate (Math/pow 2 30))}]
-                               :elapsed (util/timed start)
+                               :request-id (:request-id params)
+                               :elapsed elapsed
                                :warnings warns)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -97,7 +103,8 @@
               {:errors (errors/check
                         [not granule-links metadata-errors/empty-gnl-data-files])})
 
-        params (assoc params :total-granule-input-bytes (:total-granule-input-bytes raw-params))
+        params (assoc params :total-granule-input-bytes (:total-granule-input-bytes raw-params)
+                             :request-id (:request-id raw-params))
         fmt (:format params)]
     (log/trace "raw-params:" raw-params)
     (log/debug "Got format:" fmt)

--- a/src/cmr/sizing/core.clj
+++ b/src/cmr/sizing/core.clj
@@ -103,8 +103,7 @@
               {:errors (errors/check
                         [not granule-links metadata-errors/empty-gnl-data-files])})
 
-        params (assoc params :total-granule-input-bytes (:total-granule-input-bytes raw-params)
-                             :request-id (:request-id raw-params))
+        params (assoc params :total-granule-input-bytes (:total-granule-input-bytes raw-params))
         fmt (:format params)]
     (log/trace "raw-params:" raw-params)
     (log/debug "Got format:" fmt)

--- a/src/cmr/sizing/spatial.clj
+++ b/src/cmr/sizing/spatial.clj
@@ -1,4 +1,6 @@
-(ns cmr.sizing.spatial)
+(ns cmr.sizing.spatial
+  (:require
+    [taoensso.timbre :as log]))
 
 (defn tiling-type->size
   "Convert the tiling type to height and width, with can be used calculating square degrees."
@@ -42,6 +44,10 @@
         tt-sq-degs (tiling-type->square-degrees tiling-type)
         bbox-sq-degs (bbox->square-degrees
                       (get-in results [:params :bounding-box]))]
+    (log/info (format (str "request-id: %s format-estimate: %s tiling-type: %s tt-sq-degs: %s "
+                           "bbox-sq-degs: %s")
+                      (get-in results [:params :request-id]) format-estimate tiling-type
+                      tt-sq-degs bbox-sq-degs))
     (cond (nil? bbox-sq-degs)
           format-estimate
 


### PR DESCRIPTION
This PR adds a UUID request id, and logs any relevant data used in the size estimation calculation, the format estimate (prior to spatial) then the final estimate, and the elapsed duration.